### PR TITLE
[DT-038462] OpenAI Module: Duplicate 'Cancel Fine Tune' steps are sho…

### DIFF
--- a/Decisions.OpenAI/Steps/FineTuneSteps/ListFineTuneEvents.cs
+++ b/Decisions.OpenAI/Steps/FineTuneSteps/ListFineTuneEvents.cs
@@ -11,9 +11,9 @@ using DecisionsFramework.Design.Properties;
 namespace Decisions.OpenAI.Steps.FineTuneSteps
 {
     [Writable]
-    [AutoRegisterStep("Get Fine Tune Events", "Integration/OpenAI/Fine-Tune")]
+    [AutoRegisterStep("List Fine Tune Events", "Integration/OpenAI/Fine-Tune")]
     [ShapeImageAndColorProvider(null, OpenAISettings.OPEN_AI_IMAGES_PATH)]
-    public class GetFineTuneEvents : ISyncStep, IDataConsumer
+    public class ListFineTuneEvents : ISyncStep, IDataConsumer
     {
         private const string PATH_DONE = "Done";
         


### PR DESCRIPTION
…wn in the FINE-TUNE section.
Completely replaced "Get Fine Tune Events" step with "List Fine Tune Events" as it's named in the OpenAI API Reference. This is recognized as a new step that will not adopt the mistaken "Cancel Fine Tune" name when upgraded from 8.10